### PR TITLE
Fix output buffer overflow

### DIFF
--- a/ascii85.h
+++ b/ascii85.h
@@ -43,6 +43,10 @@ int32_t encode_ascii85 (const uint8_t *inp, int32_t in_length, uint8_t *outp, in
 
 int32_t decode_ascii85 (const uint8_t *inp, int32_t in_length, uint8_t *outp, int32_t out_max_length);
 
+int32_t ascii85_get_max_encoded_length (uint32_t in_length);
+
+int32_t ascii85_get_max_decoded_length (uint32_t in_length);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This fixes a buffer overflow present in `decode_ascii85()` when trying to decode data that was mostly zeros.

The easiest way to reproduce this issue on current `HEAD` (7854f7872f718e4fe699796f8eea93894ec16d9b) is:
```
$ make test
$ ./test -o zzzzzzzzzz
```
which reliably generates a segfault on my machine. If it doesn't, try adding a few more `z`'s :P

To fix this I've introduced `ascii85_get_max_decoded_length()` since the option to enable `z` coding is an internal implementation detail, as well as `ascii85_get_max_encoded_length()` for consistency.